### PR TITLE
Support for A/V delay with "-delay"

### DIFF
--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -27,6 +27,7 @@
 
 #ifdef HAVE_ALSA
 extern AUDIO_RENDERER_CALLBACKS audio_callbacks_alsa;
+void alsa_set_audio_init_delay(int delaySec);
 #endif
 #ifdef HAVE_SDL
 extern AUDIO_RENDERER_CALLBACKS audio_callbacks_sdl;

--- a/src/config.c
+++ b/src/config.c
@@ -63,6 +63,7 @@ static struct option long_options[] = {
   {"viewonly", no_argument, NULL, '2'},
   {"rotate", required_argument, NULL, '3'},
   {"logging", no_argument, NULL, '4'},
+  {"delay", required_argument, NULL, '5'},
   {"verbose", no_argument, NULL, 'z'},
   {"debug", no_argument, NULL, 'Z'},
   {0, 0, 0, 0},
@@ -116,6 +117,9 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
   case '4':
     config->log_file_enabled = true;
     initialize_log();
+    break;
+  case '5':
+    config->stream_start_delay = atoi(value);
     break;
   case 'l':
     config->sops = false;
@@ -282,6 +286,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   config->quitappafter = false;
   config->viewonly = false;
   config->rotate = 0;
+  config->stream_start_delay = -1;
   config->codec = CODEC_UNSPECIFIED;
 
   config->inputsCount = 0;

--- a/src/config.h
+++ b/src/config.h
@@ -41,6 +41,7 @@ typedef struct _CONFIGURATION {
   bool fullscreen;
   bool log_file_enabled;
   int rotate;
+  int stream_start_delay;
   bool unsupported;
   bool quitappafter;
   bool viewonly;

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
+#define _GNU_SOURCE
 
 #include "loop.h"
 #include "connection.h"
@@ -41,7 +42,7 @@
 
 #include <client.h>
 #include <discover.h>
-
+#include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -141,6 +142,11 @@ static void stream(PSERVER_DATA server, PCONFIGURATION config, enum platform sys
     loop_init();
 
   platform_start(system);
+  #ifdef HAVE_AML
+  if(config->stream_start_delay >= 0) {
+    ((void (*)(int)) dlsym(RTLD_DEFAULT, "aml_set_video_init_delay"))(config->stream_start_delay);
+  }
+  #endif
   LiStartConnection(&server->serverInfo, &config->stream, &connection_callbacks, platform_get_video(system), platform_get_audio(system, config->audio_device), NULL, drFlags, config->audio_device, 0);
 
   if (IS_EMBEDDED(system)) {

--- a/src/main.c
+++ b/src/main.c
@@ -144,6 +144,7 @@ static void stream(PSERVER_DATA server, PCONFIGURATION config, enum platform sys
   platform_start(system);
   #ifdef HAVE_AML
   if(config->stream_start_delay >= 0) {
+    alsa_set_audio_init_delay(config->stream_start_delay);
     ((void (*)(int)) dlsym(RTLD_DEFAULT, "aml_set_video_init_delay"))(config->stream_start_delay);
   }
   #endif

--- a/src/main.c
+++ b/src/main.c
@@ -205,6 +205,9 @@ static void help() {
   #if defined(HAVE_PI) | defined(HAVE_MMAL)
   printf("\t-rotate <height>\tRotate display: 0/90/180/270 (default 0)\n");
   #endif
+  #if defined(HAVE_AML)
+  printf("\t-delay <N>\t\tDelay playing A/V stream until N seconds passes (default 0)\n");
+  #endif
   printf("\t-fps <fps>\t\tSpecify the fps to use (default -1)\n");
   printf("\t-bitrate <bitrate>\tSpecify the bitrate in Kbps\n");
   printf("\t-packetsize <size>\tSpecify the maximum packetsize in bytes\n");


### PR DESCRIPTION
**Description**
Allows the user to specify the time in seconds to delay the start of A/V playback.
**Purpose**
Useful for displaying other content while the game is loading in the background.